### PR TITLE
Potential fix for code scanning alert no. 29: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.js.yaml
+++ b/.github/workflows/test.js.yaml
@@ -1,4 +1,6 @@
 name: Test coverage report 
+permissions:
+  contents: read
 
 on:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/ONSdigital/blaise-design-system-react-components/security/code-scanning/29](https://github.com/ONSdigital/blaise-design-system-react-components/security/code-scanning/29)

To fix this problem, explicitly add a `permissions` block to the workflow, as recommended by GitHub and CodeQL. Since the shown jobs only need to read repository contents, set `permissions: contents: read` at the top level of the workflow to apply to all jobs by default. Edit the `.github/workflows/test.js.yaml` file and insert the following at the top, right after (or before) the `name` field, and before the `on:` block. This does not break or change existing functionality and ensures the workflow tokens have strictly the least required privileges.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
