### PR TITLE
Potential fix for code scanning alert no. 27: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/storybook.yml
+++ b/.github/workflows/storybook.yml
@@ -6,6 +6,8 @@ on:
 jobs:
   build-and-deploy:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Checkout 🛎️
         uses: actions/checkout@v2.3.1


### PR DESCRIPTION
Potential fix for [https://github.com/ONSdigital/blaise-design-system-react-components/security/code-scanning/27](https://github.com/ONSdigital/blaise-design-system-react-components/security/code-scanning/27)

The best fix is to explicitly add a `permissions` block specifying the minimal permissions required by the workflow. The `JamesIves/github-pages-deploy-action` only needs `contents: write` to push to the `docs` branch (GitHub Pages), so set `contents: write` at the job level (for `build-and-deploy`). This restricts `GITHUB_TOKEN` permissions only to what's necessary for the job, following the principle of least privilege. You should add:

```yaml
permissions:
  contents: write
```

directly under the job definition (`build-and-deploy:`), at the same indentation level as `runs-on`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
